### PR TITLE
Fix kubeadm init detection.

### DIFF
--- a/vagrant/provision/provision_master.sh
+++ b/vagrant/provision/provision_master.sh
@@ -36,11 +36,11 @@ echo "export KUBEADM_TOKEN=$(kubeadm token generate)" >> /vagrant/config/init
 
 . /vagrant/config/init
 
-if [ ! -f "/vagrant/config/kubadm-init-done" ]; then
+if [ ! -f "/etc/kubernetes/admin.conf" ]; then
   echo "Initiate kubeadm"
+  sudo kubeadm config images pull
   sudo kubeadm init --apiserver-advertise-address=${base_ip6}0::$self_id \
     --service-cidr=$k8s_service_cidr:/110 --node-name=k86-master --token=$KUBEADM_TOKEN | tee /vagrant/config/cert
-  touch "/vagrant/config/kubadm-init-done"
 fi
 
 echo "kubectl config for user $(id -u)"


### PR DESCRIPTION
Currently after `vagrant destroy` invoking `vagrant up` fails.

kubeadm init generates the file `/etc/kubernetes/admin.conf` therefore a separate state file is not required.