### PR TITLE
Fix join command with k8s

### DIFF
--- a/vagrant/provision/provision_master.sh
+++ b/vagrant/provision/provision_master.sh
@@ -39,8 +39,9 @@ echo "export KUBEADM_TOKEN=$(kubeadm token generate)" >> /vagrant/config/init
 if [ ! -f "/vagrant/config/kubadm-init-done" ]; then
   echo "Initiate kubeadm"
   sudo kubeadm init --apiserver-advertise-address=${base_ip6}0::$self_id \
-    --service-cidr=$k8s_service_cidr:/110 --node-name=k86-master --token=$KUBEADM_TOKEN | tee /vagrant/config/cert
-  touch "/vagrant/config/kubadm-init-done"
+    --service-cidr=$k8s_service_cidr:/110 --node-name=k86-master --token=$KUBEADM_TOKEN
+  sudo kubeadm token create --print-join-command > /vagrant/config/join.sh
+  sudo chmod a+x /vagrant/config/join.sh
 fi
 
 echo "kubectl config for user $(id -u)"

--- a/vagrant/provision/provision_worker.sh
+++ b/vagrant/provision/provision_worker.sh
@@ -61,7 +61,6 @@ EOF
 
 if [ ! -f "/vagrant/config/kubadm-join-${self_name}-done" ]; then
   echo "Initiate kubeadm join sequence !"
-  cmd=$(grep "^  kubeadm join" /vagrant/config/cert)
-  sudo $cmd
+  sudo /vagrant/config/join.sh
   touch "/vagrant/config/kubadm-join-${self_name}-done"
 fi


### PR DESCRIPTION
The join command fails with k8s 1.15.

1. The join command is no longer on the beginning of the first line (`grep "^  kubeadm join"` does no longer match)
2. The join command contains a linebreak

The command `kubeadm token create --print-join-command` could be used to just print the join command.